### PR TITLE
Add ~8notbot command

### DIFF
--- a/cogs/general.py
+++ b/cogs/general.py
@@ -121,11 +121,16 @@ I choose: {}!""".format(choice_str, random.choice(choice_list)))
     async def eightnotbot(self, *q: str):
         """Given a question, randomly select an online user that isn't a bot."""
         member_list = list(self.bot.get_all_members())
-        while True:
-            user = random.choice(member_list)
-            if user.status == user.status.online and user.bot == false
-                break
-        await self.bot.replay('`{}`: {}'.format(' '.join(q), user.display_name))
+        online_member_list = []
+        for m in member_list:
+            if m.status == m.status.online and m.bot == False:
+                online_member_list.append(m)
+        user = random.choice(member_list)
+        if len(online_member_list) > 0:
+            user = random.choice(online_member_list)
+            await self.bot.reply('`{}`: {}'.format(' '.join(q), user.display_name))
+        else:
+            await self.bot.reply('`{}`: No non-bots are online.'.format(' '.join(q)))
 
     @commands.command(name='8date')
     async def eightdate(self, *args: str):

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -117,6 +117,16 @@ I choose: {}!""".format(choice_str, random.choice(choice_list)))
                 break
         await self.bot.reply('`{}`: {}'.format(' '.join(q), user.display_name))
 
+    @commands.command(name='8notbot')
+    async def eightnotbot(self, *q: str):
+        """Given a question, randomly select an online user that isn't a bot."""
+        member_list = list(self.bot.get_all_members())
+        while True:
+            user = random.choice(member_list)
+            if user.status == user.status.online and user.bot == false
+                break
+        await self.bot.replay('`{}`: {}'.format(' '.join(q), user.display_name))
+
     @commands.command(name='8date')
     async def eightdate(self, *args: str):
         """Generate a random date."""


### PR DESCRIPTION
Typing `~8notbot [message]` into chat selects a random online user which is not a bot. If no non-bots are online, a message explaining that will be sent instead.
There's probably a more optimised way of collecting the online non-bots into the `online_member_list`, but I don't know how to do it.

It works on my machine.